### PR TITLE
Test for LINESTRING type in weight_streetnet

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Minor changes
 
+- `weight_streetnet` now raises a warning (instead of an error) in case the input `sf` object has mixed geometry types instead of only `LINESTRING`. The function filters only the geometries having `LINESTRING` type (#246, thanks to @agila5).
 - Pre-pend class structure of `dodgr_streetnet` objects to `data.frame`, rather than append; thanks to @agila5 (#244).
 - Fix bug in graph contraction that left duplicated edges (#236, thanks to @Robinlovelace).
 - Fix minor bug in de-duplication discovered via #236.

--- a/R/weight-streetnet.R
+++ b/R/weight-streetnet.R
@@ -224,7 +224,34 @@ weight_streetnet.sf <- function (x,
     # Then rename geom_column to "geometry" for the C++ routine
     names (x) [match (geom_column, names (x))] <- "geometry"
     attr (x, "sf_column") <- "geometry"
-
+    
+    # Currently, the C++ routine only works with LINESTRING geometries (as
+    # documented in the docs). The following code tests the type of the geometry
+    # column. See #246 for more details. 
+    idx_LINESTRING <- inherits(x [["geometry"]], "sfc_LINESTRING")
+    
+    if (!idx_LINESTRING) { 
+      # Now can assume that at least one of the geometries included in
+      # x[["geometry"]] is not a LINESTRING. We are going to raise a warning
+      # message and filter the LINESTRING geometries
+      warning(
+        "At least one of the input geometries is not a LINESTRING. Discarding them.", 
+        call. = FALSE
+      )
+    
+      idx_LINESTRING <- vapply(
+        x [["geometry"]], 
+        inherits, 
+        logical(1),
+        what = "LINESTRING"
+      )
+      x <- x[idx_LINESTRING, ]
+      
+      if (nrow(x) == 0L) {
+        stop("No input geometry has LINESTRING type", call. = FALSE)
+      }
+    }
+      
     wp <- get_wt_profile (x, wt_profile, wt_profile_file)
     # convert oneway and oneway*bicycle values to boolean (fn is in
     # wt_streetnet-times.R):

--- a/tests/testthat/test-streetnet.R
+++ b/tests/testthat/test-streetnet.R
@@ -250,3 +250,24 @@ test_that ("streetnet times", {
         "Custom named profiles must be vectors"
     )
 })
+
+test_that("weight_streetnet runs with non-LINESTRING sfc", {
+  # See #246
+  skip_if_not_installed("sf")
+  
+  toy <- sf::st_as_sf(
+    data.frame(highway = "primary", osm_id = 1:2), 
+    geometry = sf::st_sfc(
+      sf::st_linestring(rbind(c(0, 0), c(1, 1))), 
+      sf::st_multilinestring(
+        list(
+          sf::st_linestring(rbind(c(1, 1), c(2, 2)))
+        )
+      )
+    )
+  )
+  expect_warning(
+    weight_streetnet(toy),
+    "not a LINESTRING"
+  )
+})


### PR DESCRIPTION
Fixes #246. 

I'm not sure if we can do something better to accept also MULTILINESTRING(s), but I think this is good enough for the moment. Reprex of the new behaviour

``` r
library(dodgr)
toy <- structure(
  list(
    highway = c("primary", "primary"),
    osm_id = c(1L, 2L), 
    geometry = structure(
      list(
        structure(c(0, 1, 0, 1),
          dim = c(2L, 2L), class = c(
            "XY",
            "LINESTRING", "sfg"
          )
        ), structure(list(structure(c(
          1, 2, 1,
          2
        ), dim = c(2L, 2L), class = c("XY", "LINESTRING", "sfg"))), class = c(
          "XY",
          "MULTILINESTRING", "sfg"
        ))
      ),
      class = c("sfc_GEOMETRY", "sfc"), precision = 0, bbox = structure(c(
        xmin = 0, ymin = 0, xmax = 2,
        ymax = 2
      ), class = "bbox"), crs = structure(list(
        input = NA_character_,
        wkt = NA_character_
      ), class = "crs"), classes = c(
        "LINESTRING",
        "MULTILINESTRING"
      ), n_empty = 0L
    )
  ),
  row.names = 1:2, class = c(
    "sf",
    "data.frame"
  ), sf_column = "geometry", agr = structure(c(highway = NA_integer_), class = "factor", levels = c(
    "constant",
    "aggregate", "identity"
  ))
)
weight_streetnet(toy)
#> Warning: At least one of the input geometries is not a LINESTRING. Discarding
#> them.
#>   geom_num edge_id from_id from_lon from_lat to_id to_lon to_lat        d
#> 1        1       1       0        0        0     1      1      1 156899.6
#> 2        1       2       1        1        1     0      0      0 156899.6
#>   d_weighted highway way_id component    time time_weighted
#> 1   224142.2 primary      1         1 37655.9      53794.14
#> 2   224142.2 primary      1         1 37655.9      53794.14
```

<sup>Created on 2024-09-24 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.3.1 (2023-06-16 ucrt)
#>  os       Windows 11 x64 (build 22631)
#>  system   x86_64, mingw32
#>  ui       RTerm
#>  language (EN)
#>  collate  English_United Kingdom.utf8
#>  ctype    English_United Kingdom.utf8
#>  tz       Europe/Rome
#>  date     2024-09-24
#>  pandoc   3.1.1 @ C:/Program Files/RStudio/resources/app/bin/quarto/bin/tools/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package      * version   date (UTC) lib source
#>  cachem         1.1.0     2024-05-16 [1] CRAN (R 4.3.3)
#>  callr          3.7.6     2024-03-25 [1] CRAN (R 4.3.3)
#>  cli            3.6.3     2024-06-21 [1] CRAN (R 4.3.1)
#>  digest         0.6.35    2024-03-11 [1] CRAN (R 4.3.3)
#>  dodgr        * 0.4.1.026 2024-09-24 [1] local
#>  evaluate       0.24.0    2024-06-10 [1] CRAN (R 4.3.3)
#>  fastmap        1.2.0     2024-05-15 [1] CRAN (R 4.3.3)
#>  fs             1.6.4     2024-04-25 [1] CRAN (R 4.3.3)
#>  geodist        0.1.0     2024-05-23 [1] CRAN (R 4.3.1)
#>  glue           1.7.0     2024-01-09 [1] CRAN (R 4.3.2)
#>  htmltools      0.5.8.1   2024-04-04 [1] CRAN (R 4.3.3)
#>  knitr          1.48      2024-07-07 [1] CRAN (R 4.3.3)
#>  lifecycle      1.0.4     2023-11-07 [1] CRAN (R 4.3.2)
#>  magrittr       2.0.3     2022-03-30 [1] CRAN (R 4.3.1)
#>  memoise        2.0.1     2021-11-26 [1] CRAN (R 4.3.1)
#>  osmdata        0.2.5     2023-08-14 [1] CRAN (R 4.3.1)
#>  processx       3.8.4     2024-03-16 [1] CRAN (R 4.3.3)
#>  ps             1.7.6     2024-01-18 [1] CRAN (R 4.3.3)
#>  purrr          1.0.2     2023-08-10 [1] CRAN (R 4.3.1)
#>  R.cache        0.16.0    2022-07-21 [1] CRAN (R 4.3.1)
#>  R.methodsS3    1.8.2     2022-06-13 [1] CRAN (R 4.3.1)
#>  R.oo           1.25.0    2022-06-12 [1] CRAN (R 4.3.1)
#>  R.utils        2.12.2    2022-11-11 [1] CRAN (R 4.3.1)
#>  R6             2.5.1     2021-08-19 [1] CRAN (R 4.3.1)
#>  Rcpp           1.0.13    2024-07-17 [1] CRAN (R 4.3.1)
#>  RcppParallel   5.1.7     2023-02-27 [1] CRAN (R 4.3.1)
#>  reprex         2.0.2     2022-08-17 [1] CRAN (R 4.3.1)
#>  rlang          1.1.4     2024-06-04 [1] CRAN (R 4.3.1)
#>  rmarkdown      2.27      2024-05-17 [1] CRAN (R 4.3.3)
#>  rstudioapi     0.16.0    2024-03-24 [1] CRAN (R 4.3.1)
#>  sessioninfo    1.2.2     2021-12-06 [1] CRAN (R 4.3.1)
#>  styler         1.10.2    2023-08-29 [1] CRAN (R 4.3.1)
#>  vctrs          0.6.5     2023-12-01 [1] CRAN (R 4.3.2)
#>  withr          3.0.1     2024-07-31 [1] CRAN (R 4.3.3)
#>  xfun           0.45      2024-06-16 [1] CRAN (R 4.3.3)
#>  yaml           2.3.9     2024-07-05 [1] CRAN (R 4.3.3)
#> 
#>  [1] C:/Users/user/AppData/Local/R/win-library/4.3
#>  [2] C:/Program Files/R/R-4.3.1/library
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>
