### PR TITLE
Update match-points.R fix the case where which_side is zero.

### DIFF
--- a/R/match-points.R
+++ b/R/match-points.R
@@ -222,7 +222,7 @@ signed_intersection_dists <- function (graph, xy, res) {
     which_side <- (gxy$xto - gxy$xfr) * (xy_intersect$y - gxy$yfr) -
         (gxy$yto - gxy$yfr) * (xy_intersect$x - gxy$xfr)
     which_side [which_side < 0.0] <- -1
-    which_side [which_side > 0.0] <- 1
+    which_side [which_side >= 0.0] <- 1
 
     return (cbind (d_signed = d * which_side, xy_intersect))
 }


### PR DESCRIPTION
point might  not be on the edge, but distances will be set to zero. fix this with >= instead of >

library(dodgr)
xynow <- structure(c(-67.051535, -10.07351), dim = 1:2, dimnames = list(NULL, c("X", "Y"))) g <- structure(list(geom_num = 18427, edge_id = 1202325L, from_id = "599145", 
                    from_lon = -68.7645434, from_lat = -10.902849, to_id = "599146", 
                    to_lon = -68.761711, to_lat = -10.9026804, d = 310.208194002291, 
                    d_weighted = 517.013656670486, highway = "unclassified", 
                    lanes = NA_character_, way_id = "18457", component = 1L, 
                    time = 44.66997993633, time_weighted = 74.4499665605499, 
                    point_x = -68.761519, point_y = -10.901526, proj_x = -68.761711, 
                    proj_y = -10.9026804), row.names = c(NA, -1L), class = "data.frame")

dodgr::match_pts_to_graph(graph = g, xy = xynow, connected = FALSE, distances = TRUE)