### PR TITLE
Add weighted distances option to dodgr_distsFix/weighted distances

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -6,14 +6,14 @@
 #' sample is used to estimate timing, by calculating centrality from just a few
 #' vertices.
 #' @noRd
-rcpp_centrality <- function (graph, vert_map_in, heap_type, dist_threshold, edge_centrality, sample) {
-    .Call (`_dodgr_rcpp_centrality`, graph, vert_map_in, heap_type, dist_threshold, edge_centrality, sample)
+rcpp_centrality <- function(graph, vert_map_in, heap_type, dist_threshold, edge_centrality, sample) {
+    .Call(`_dodgr_rcpp_centrality`, graph, vert_map_in, heap_type, dist_threshold, edge_centrality, sample)
 }
 
 #' rcpp_concaveman
-#' @noRd
-rcpp_concaveman <- function (xy, hull_in, concavity, length_threshold) {
-    .Call (`_dodgr_rcpp_concaveman`, xy, hull_in, concavity, length_threshold)
+#' @noRd 
+rcpp_concaveman <- function(xy, hull_in, concavity, length_threshold) {
+    .Call(`_dodgr_rcpp_concaveman`, xy, hull_in, concavity, length_threshold)
 }
 
 #' De-duplicate edges by replacing with minimal weighted distances and times
@@ -28,8 +28,8 @@ rcpp_concaveman <- function (xy, hull_in, concavity, length_threshold) {
 #' minimal value taken from all duplicated edges. If 't_col' is specified, the
 #' equivalent minimal times are in the lower half of the result.
 #' @noRd
-rcpp_deduplicate <- function (graph, fr_col, to_col, d_col, t_col) {
-    .Call (`_dodgr_rcpp_deduplicate`, graph, fr_col, to_col, d_col, t_col)
+rcpp_deduplicate <- function(graph, fr_col, to_col, d_col, t_col) {
+    .Call(`_dodgr_rcpp_deduplicate`, graph, fr_col, to_col, d_col, t_col)
 }
 
 #' Make unordered_set of all new edge names
@@ -64,8 +64,8 @@ NULL
 #' @return Rcpp::List object of `sf::LINESTRING` geoms
 #'
 #' @noRd
-rcpp_aggregate_to_sf <- function (graph_full, graph_contr, edge_map) {
-    .Call (`_dodgr_rcpp_aggregate_to_sf`, graph_full, graph_contr, edge_map)
+rcpp_aggregate_to_sf <- function(graph_full, graph_contr, edge_map) {
+    .Call(`_dodgr_rcpp_aggregate_to_sf`, graph_full, graph_contr, edge_map)
 }
 
 #' rcpp_flows_aggregate_par
@@ -86,8 +86,8 @@ rcpp_aggregate_to_sf <- function (graph_full, graph_contr, edge_map) {
 #' characters long, that chance should be 1 / 62 ^ 10.
 #'
 #' @noRd
-rcpp_flows_aggregate_par <- function (graph, vert_map_in, fromi, toi_in, flows, norm_sums, tol, heap_type) {
-    .Call (`_dodgr_rcpp_flows_aggregate_par`, graph, vert_map_in, fromi, toi_in, flows, norm_sums, tol, heap_type)
+rcpp_flows_aggregate_par <- function(graph, vert_map_in, fromi, toi_in, flows, norm_sums, tol, heap_type) {
+    .Call(`_dodgr_rcpp_flows_aggregate_par`, graph, vert_map_in, fromi, toi_in, flows, norm_sums, tol, heap_type)
 }
 
 #' rcpp_flows_aggregate_pairwise
@@ -110,8 +110,8 @@ rcpp_flows_aggregate_par <- function (graph, vert_map_in, fromi, toi_in, flows, 
 #' characters long, that chance should be 1 / 62 ^ 10.
 #'
 #' @noRd
-rcpp_flows_aggregate_pairwise <- function (graph, vert_map_in, fromi, toi, flows, norm_sums, tol, heap_type) {
-    .Call (`_dodgr_rcpp_flows_aggregate_pairwise`, graph, vert_map_in, fromi, toi, flows, norm_sums, tol, heap_type)
+rcpp_flows_aggregate_pairwise <- function(graph, vert_map_in, fromi, toi, flows, norm_sums, tol, heap_type) {
+    .Call(`_dodgr_rcpp_flows_aggregate_pairwise`, graph, vert_map_in, fromi, toi, flows, norm_sums, tol, heap_type)
 }
 
 #' rcpp_flows_disperse_par
@@ -132,8 +132,8 @@ rcpp_flows_aggregate_pairwise <- function (graph, vert_map_in, fromi, toi, flows
 #' between each pair of from and to points.
 #'
 #' @noRd
-rcpp_flows_disperse_par <- function (graph, vert_map_in, fromi, k, dens, tol, heap_type) {
-    .Call (`_dodgr_rcpp_flows_disperse_par`, graph, vert_map_in, fromi, k, dens, tol, heap_type)
+rcpp_flows_disperse_par <- function(graph, vert_map_in, fromi, k, dens, tol, heap_type) {
+    .Call(`_dodgr_rcpp_flows_disperse_par`, graph, vert_map_in, fromi, k, dens, tol, heap_type)
 }
 
 #' rcpp_flows_si
@@ -149,13 +149,13 @@ rcpp_flows_disperse_par <- function (graph, vert_map_in, fromi, k, dens, tol, he
 #' (to-vertices) are not considered.
 #'
 #' @noRd
-rcpp_flows_si <- function (graph, vert_map_in, fromi, toi_in, kvec, dens_from, dens_to, norm_sums, tol, heap_type) {
-    .Call (`_dodgr_rcpp_flows_si`, graph, vert_map_in, fromi, toi_in, kvec, dens_from, dens_to, norm_sums, tol, heap_type)
+rcpp_flows_si <- function(graph, vert_map_in, fromi, toi_in, kvec, dens_from, dens_to, norm_sums, tol, heap_type) {
+    .Call(`_dodgr_rcpp_flows_si`, graph, vert_map_in, fromi, toi_in, kvec, dens_from, dens_to, norm_sums, tol, heap_type)
 }
 
 #' @noRd
-rcpp_fundamental_cycles <- function (graph, verts) {
-    .Call (`_dodgr_rcpp_fundamental_cycles`, graph, verts)
+rcpp_fundamental_cycles <- function(graph, verts) {
+    .Call(`_dodgr_rcpp_fundamental_cycles`, graph, verts)
 }
 
 #' get_to_from
@@ -170,7 +170,7 @@ NULL
 #' same_hwy_type
 #'
 #' Determine whether two edges represent the same weight category (type of
-#' highway for street networks, for example). Categories are not retained in
+#' highway for street networks, for example). Categories are not retained in 
 #' converted graphs, but can be discerned by comparing ratios of weighted to
 #' non-weighted distances.
 #' @noRd
@@ -188,8 +188,8 @@ NULL
 #' original and contracted graph.
 #'
 #' @noRd
-rcpp_contract_graph <- function (graph, vertlist_in) {
-    .Call (`_dodgr_rcpp_contract_graph`, graph, vertlist_in)
+rcpp_contract_graph <- function(graph, vertlist_in) {
+    .Call(`_dodgr_rcpp_contract_graph`, graph, vertlist_in)
 }
 
 #' rcpp_merge_cols
@@ -203,8 +203,8 @@ rcpp_contract_graph <- function (graph, vertlist_in) {
 #' those edges to be retained in the directed graph.
 #'
 #' @noRd
-rcpp_merge_cols <- function (graph) {
-    .Call (`_dodgr_rcpp_merge_cols`, graph)
+rcpp_merge_cols <- function(graph) {
+    .Call(`_dodgr_rcpp_merge_cols`, graph)
 }
 
 #' sample_one_edge_no_comps
@@ -213,7 +213,7 @@ rcpp_merge_cols <- function (graph) {
 #' in \code{sample_one_vertex}
 #'
 #' @param edge_map edge_map
-#' @return std::vector of 2 elements: [0] with value of largest connected
+#' @return std::vector of 2 elements: [0] with value of largest connected 
 #' component; [1] with random index to one edge that is part of that component.
 #' @noRd
 NULL
@@ -240,8 +240,8 @@ NULL
 #' @return Smaller sub-set of \code{graph}
 #'
 #' @noRd
-rcpp_sample_graph <- function (graph, nverts_to_sample) {
-    .Call (`_dodgr_rcpp_sample_graph`, graph, nverts_to_sample)
+rcpp_sample_graph <- function(graph, nverts_to_sample) {
+    .Call(`_dodgr_rcpp_sample_graph`, graph, nverts_to_sample)
 }
 
 #' graph_has_components
@@ -253,7 +253,7 @@ NULL
 
 #' @name graph_from_df
 #'
-#' Convert a standard graph data.frame into an object of class graph. Graphs
+#' Convert a standard graph data.frame into an object of class graph. Graphs 
 #' are standardised with the function \code{dodgr_convert_graph()$graph}, and
 #' contain only the four columns [from, to, d, w]
 #'
@@ -263,7 +263,7 @@ NULL
 #' identify_graph_components
 #'
 #' Identify initial graph components for each **vertex**
-#' Identification for edges is subsequently perrformed with
+#' Identification for edges is subsequently perrformed with 
 #' \code{rcpp_get_component_vector}.
 #'
 #' @param v unordered_map <vertex_id_t, vertex_t>
@@ -281,8 +281,8 @@ NULL
 #' @return Two vectors: one of edge IDs and one of corresponding component
 #' numbers
 #' @noRd
-rcpp_get_component_vector <- function (graph) {
-    .Call (`_dodgr_rcpp_get_component_vector`, graph)
+rcpp_get_component_vector <- function(graph) {
+    .Call(`_dodgr_rcpp_get_component_vector`, graph)
 }
 
 #' rcpp_unique_rownames
@@ -291,8 +291,8 @@ rcpp_get_component_vector <- function (graph) {
 #' rounded to <precision>. Used when vertices have no ID values.
 #'
 #' @noRd
-rcpp_unique_rownames <- function (xyfrom, xyto, precision = 10L) {
-    .Call (`_dodgr_rcpp_unique_rownames`, xyfrom, xyto, precision)
+rcpp_unique_rownames <- function(xyfrom, xyto, precision = 10L) {
+    .Call(`_dodgr_rcpp_unique_rownames`, xyfrom, xyto, precision)
 }
 
 #' Determine which side of intersecting line a point lies on.
@@ -325,8 +325,8 @@ NULL
 #' @return 0-indexed Rcpp::NumericVector index into graph of nearest points
 #'
 #' @noRd
-rcpp_points_index_par <- function (xy, pts) {
-    .Call (`_dodgr_rcpp_points_index_par`, xy, pts)
+rcpp_points_index_par <- function(xy, pts) {
+    .Call(`_dodgr_rcpp_points_index_par`, xy, pts)
 }
 
 #' rcpp_points_to_edges_par
@@ -339,43 +339,43 @@ rcpp_points_index_par <- function (xy, pts) {
 #' @return 0-indexed Rcpp::NumericVector index into graph of nearest points
 #'
 #' @noRd
-rcpp_points_to_edges_par <- function (graph, pts) {
-    .Call (`_dodgr_rcpp_points_to_edges_par`, graph, pts)
+rcpp_points_to_edges_par <- function(graph, pts) {
+    .Call(`_dodgr_rcpp_points_to_edges_par`, graph, pts)
 }
 
 #' rcpp_get_sp_dists_par
 #'
 #' @noRd
-rcpp_get_sp_dists_par <- function (graph, vert_map_in, fromi, toi_in, heap_type, is_spatial) {
-    .Call (`_dodgr_rcpp_get_sp_dists_par`, graph, vert_map_in, fromi, toi_in, heap_type, is_spatial)
+rcpp_get_sp_dists_par <- function(graph, vert_map_in, fromi, toi_in, heap_type, is_spatial, return_weighted) {
+    .Call(`_dodgr_rcpp_get_sp_dists_par`, graph, vert_map_in, fromi, toi_in, heap_type, is_spatial, return_weighted)
 }
 
 #' rcpp_get_sp_dists_nearest
 #'
 #' @noRd
-rcpp_get_sp_dists_nearest <- function (graph, vert_map_in, fromi, toi_in, heap_type) {
-    .Call (`_dodgr_rcpp_get_sp_dists_nearest`, graph, vert_map_in, fromi, toi_in, heap_type)
+rcpp_get_sp_dists_nearest <- function(graph, vert_map_in, fromi, toi_in, heap_type, return_weighted) {
+    .Call(`_dodgr_rcpp_get_sp_dists_nearest`, graph, vert_map_in, fromi, toi_in, heap_type, return_weighted)
 }
 
 #' rcpp_get_sp_dists_paired_par
 #'
 #' @noRd
-rcpp_get_sp_dists_paired_par <- function (graph, vert_map_in, fromi, toi, heap_type, is_spatial) {
-    .Call (`_dodgr_rcpp_get_sp_dists_paired_par`, graph, vert_map_in, fromi, toi, heap_type, is_spatial)
+rcpp_get_sp_dists_paired_par <- function(graph, vert_map_in, fromi, toi, heap_type, is_spatial, return_weighted) {
+    .Call(`_dodgr_rcpp_get_sp_dists_paired_par`, graph, vert_map_in, fromi, toi, heap_type, is_spatial, return_weighted)
 }
 
 #' rcpp_get_iso
 #'
 #' @noRd
-rcpp_get_iso <- function (graph, vert_map_in, fromi, dlim, heap_type) {
-    .Call (`_dodgr_rcpp_get_iso`, graph, vert_map_in, fromi, dlim, heap_type)
+rcpp_get_iso <- function(graph, vert_map_in, fromi, dlim, heap_type) {
+    .Call(`_dodgr_rcpp_get_iso`, graph, vert_map_in, fromi, dlim, heap_type)
 }
 
 #' rcpp_get_sp_dists
 #'
 #' @noRd
-rcpp_get_sp_dists <- function (graph, vert_map_in, fromi, toi_in, heap_type) {
-    .Call (`_dodgr_rcpp_get_sp_dists`, graph, vert_map_in, fromi, toi_in, heap_type)
+rcpp_get_sp_dists <- function(graph, vert_map_in, fromi, toi_in, heap_type, return_weighted) {
+    .Call(`_dodgr_rcpp_get_sp_dists`, graph, vert_map_in, fromi, toi_in, heap_type, return_weighted)
 }
 
 #' rcpp_get_paths
@@ -396,12 +396,12 @@ rcpp_get_sp_dists <- function (graph, vert_map_in, fromi, toi_in, heap_type) {
 #' @note Returns 1-indexed values indexing directly into the R input
 #'
 #' @noRd
-rcpp_get_paths <- function (graph, vert_map_in, fromi, toi_in, heap_type) {
-    .Call (`_dodgr_rcpp_get_paths`, graph, vert_map_in, fromi, toi_in, heap_type)
+rcpp_get_paths <- function(graph, vert_map_in, fromi, toi_in, heap_type) {
+    .Call(`_dodgr_rcpp_get_paths`, graph, vert_map_in, fromi, toi_in, heap_type)
 }
 
-rcpp_get_paths_pairwise <- function (graph, vert_map_in, fromi, toi_in, heap_type) {
-    .Call (`_dodgr_rcpp_get_paths_pairwise`, graph, vert_map_in, fromi, toi_in, heap_type)
+rcpp_get_paths_pairwise <- function(graph, vert_map_in, fromi, toi_in, heap_type) {
+    .Call(`_dodgr_rcpp_get_paths_pairwise`, graph, vert_map_in, fromi, toi_in, heap_type)
 }
 
 #' rcpp_get_sp_dists_categorical
@@ -413,21 +413,21 @@ rcpp_get_paths_pairwise <- function (graph, vert_map_in, fromi, toi_in, heap_typ
 #' Implemented in parallal form only; no single-threaded version, and
 #' only for AStar (so graphs must be spatial).
 #' @noRd
-rcpp_get_sp_dists_categorical <- function (graph, vert_map_in, fromi, toi_in, heap_type, proportions_only) {
-    .Call (`_dodgr_rcpp_get_sp_dists_categorical`, graph, vert_map_in, fromi, toi_in, heap_type, proportions_only)
+rcpp_get_sp_dists_categorical <- function(graph, vert_map_in, fromi, toi_in, heap_type, proportions_only) {
+    .Call(`_dodgr_rcpp_get_sp_dists_categorical`, graph, vert_map_in, fromi, toi_in, heap_type, proportions_only)
 }
 
 #' rcpp_get_sp_dists_categ_paired
 #'
 #' Pairwise version of 'get_sp_dists_categorical'. The `graph` must have an
-#' `edge_type` column of non-negative integers, with 0 denoting edges which are
+#'`edge_type` column of non-negative integers, with 0 denoting edges which are
 #' not aggregated, and all other values defining aggregation categories.
 #'
 #' Implemented in parallal form only; no single-threaded version, and
 #' only for AStar (so graphs must be spatial).
 #' @noRd
-rcpp_get_sp_dists_categ_paired <- function (graph, vert_map_in, fromi, toi_in, heap_type) {
-    .Call (`_dodgr_rcpp_get_sp_dists_categ_paired`, graph, vert_map_in, fromi, toi_in, heap_type)
+rcpp_get_sp_dists_categ_paired <- function(graph, vert_map_in, fromi, toi_in, heap_type) {
+    .Call(`_dodgr_rcpp_get_sp_dists_categ_paired`, graph, vert_map_in, fromi, toi_in, heap_type)
 }
 
 #' rcpp_get_sp_dists_cat_threshold
@@ -439,8 +439,8 @@ rcpp_get_sp_dists_categ_paired <- function (graph, vert_map_in, fromi, toi_in, h
 #' Implemented in parallal form only; no single-threaded version, and
 #' only for AStar (so graphs must be spatial).
 #' @noRd
-rcpp_get_sp_dists_cat_threshold <- function (graph, vert_map_in, fromi, dlimit, heap_type) {
-    .Call (`_dodgr_rcpp_get_sp_dists_cat_threshold`, graph, vert_map_in, fromi, dlimit, heap_type)
+rcpp_get_sp_dists_cat_threshold <- function(graph, vert_map_in, fromi, dlimit, heap_type) {
+    .Call(`_dodgr_rcpp_get_sp_dists_cat_threshold`, graph, vert_map_in, fromi, dlimit, heap_type)
 }
 
 #' rcpp_gen_hash
@@ -448,8 +448,8 @@ rcpp_get_sp_dists_cat_threshold <- function (graph, vert_map_in, fromi, dlimit, 
 #' Efficient generation of long sequences of hash keys
 #'
 #' @noRd
-rcpp_gen_hash <- function (n, hash_len) {
-    .Call (`_dodgr_rcpp_gen_hash`, n, hash_len)
+rcpp_gen_hash <- function(n, hash_len) {
+    .Call(`_dodgr_rcpp_gen_hash`, n, hash_len)
 }
 
 #' rcpp_sf_as_network
@@ -475,13 +475,14 @@ rcpp_gen_hash <- function (n, hash_len) {
 #' 4. OSM way ID
 #'
 #' @noRd
-rcpp_sf_as_network <- function (sf_lines, pr) {
-    .Call (`_dodgr_rcpp_sf_as_network`, sf_lines, pr)
+rcpp_sf_as_network <- function(sf_lines, pr) {
+    .Call(`_dodgr_rcpp_sf_as_network`, sf_lines, pr)
 }
 
 #' rcpp_route_times
 #'
 #' @noRd
-rcpp_route_times <- function (graph, left_side, turn_penalty) {
-    .Call (`_dodgr_rcpp_route_times`, graph, left_side, turn_penalty)
+rcpp_route_times <- function(graph, left_side, turn_penalty) {
+    .Call(`_dodgr_rcpp_route_times`, graph, left_side, turn_penalty)
 }
+

--- a/R/dists.R
+++ b/R/dists.R
@@ -68,6 +68,8 @@
 #'
 #' @param quiet If `FALSE`, display progress messages on screen.
 #'
+#' @param return_weighted If TRUE, returns the weighted distances used for path calculation instead of geometric distances
+#'
 #' @return square matrix of distances between nodes
 #'
 #' @details `graph` must minimally contain three columns of `from`,
@@ -148,7 +150,8 @@ dodgr_dists <- function (graph,
                          pairwise = FALSE,
                          heap = "BHeap",
                          parallel = TRUE,
-                         quiet = TRUE) {
+                         quiet = TRUE,
+                         return_weighted = FALSE) {
 
     graph <- tbl_to_df (graph)
 
@@ -198,7 +201,8 @@ dodgr_dists <- function (graph,
         heap,
         is_spatial,
         parallel,
-        pairwise
+        pairwise,
+        return_weighted
     )
 
 
@@ -222,7 +226,8 @@ dodgr_distances <- function (graph,
                              pairwise = FALSE,
                              heap = "BHeap",
                              parallel = TRUE,
-                             quiet = TRUE) {
+                             quiet = TRUE,
+                             return_weighted = FALSE) {
 
     dodgr_dists (graph,
         from,
@@ -231,7 +236,8 @@ dodgr_distances <- function (graph,
         pairwise = pairwise,
         heap = heap,
         parallel = parallel,
-        quiet = quiet
+        quiet = quiet,
+        return_weighted = return_weighted
     )
 }
 
@@ -517,7 +523,8 @@ calculate_distmat <- function (graph,
                                heap,
                                is_spatial,
                                parallel = TRUE,
-                               pairwise = FALSE) {
+                               pairwise = FALSE,
+                               return_weighted = FALSE) {
 
     flip <- FALSE
     if (length (from_index$index) > length (to_index$index)) {
@@ -536,7 +543,8 @@ calculate_distmat <- function (graph,
                 from_index$index,
                 to_index$index,
                 heap,
-                is_spatial
+                is_spatial,
+                return_weighted
             )
         } else {
             d <- rcpp_get_sp_dists_par (
@@ -545,7 +553,8 @@ calculate_distmat <- function (graph,
                 from_index$index,
                 to_index$index,
                 heap,
-                is_spatial
+                is_spatial,
+                return_weighted
             )
         }
     } else {
@@ -554,7 +563,8 @@ calculate_distmat <- function (graph,
             vert_map,
             from_index$index,
             to_index$index,
-            heap
+            heap,
+            return_weighted
         )
     }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -238,8 +238,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // rcpp_get_sp_dists_par
-Rcpp::NumericMatrix rcpp_get_sp_dists_par(const Rcpp::DataFrame graph, const Rcpp::DataFrame vert_map_in, Rcpp::IntegerVector fromi, Rcpp::IntegerVector toi_in, const std::string& heap_type, const bool is_spatial);
-RcppExport SEXP _dodgr_rcpp_get_sp_dists_par(SEXP graphSEXP, SEXP vert_map_inSEXP, SEXP fromiSEXP, SEXP toi_inSEXP, SEXP heap_typeSEXP, SEXP is_spatialSEXP) {
+Rcpp::NumericMatrix rcpp_get_sp_dists_par(const Rcpp::DataFrame graph, const Rcpp::DataFrame vert_map_in, Rcpp::IntegerVector fromi, Rcpp::IntegerVector toi_in, const std::string& heap_type, const bool is_spatial, const bool return_weighted);
+RcppExport SEXP _dodgr_rcpp_get_sp_dists_par(SEXP graphSEXP, SEXP vert_map_inSEXP, SEXP fromiSEXP, SEXP toi_inSEXP, SEXP heap_typeSEXP, SEXP is_spatialSEXP, SEXP return_weightedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -249,13 +249,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type toi_in(toi_inSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type heap_type(heap_typeSEXP);
     Rcpp::traits::input_parameter< const bool >::type is_spatial(is_spatialSEXP);
-    rcpp_result_gen = Rcpp::wrap(rcpp_get_sp_dists_par(graph, vert_map_in, fromi, toi_in, heap_type, is_spatial));
+    Rcpp::traits::input_parameter< const bool >::type return_weighted(return_weightedSEXP);
+    rcpp_result_gen = Rcpp::wrap(rcpp_get_sp_dists_par(graph, vert_map_in, fromi, toi_in, heap_type, is_spatial, return_weighted));
     return rcpp_result_gen;
 END_RCPP
 }
 // rcpp_get_sp_dists_nearest
-Rcpp::NumericVector rcpp_get_sp_dists_nearest(const Rcpp::DataFrame graph, const Rcpp::DataFrame vert_map_in, Rcpp::IntegerVector fromi, Rcpp::IntegerVector toi_in, const std::string& heap_type);
-RcppExport SEXP _dodgr_rcpp_get_sp_dists_nearest(SEXP graphSEXP, SEXP vert_map_inSEXP, SEXP fromiSEXP, SEXP toi_inSEXP, SEXP heap_typeSEXP) {
+Rcpp::NumericVector rcpp_get_sp_dists_nearest(const Rcpp::DataFrame graph, const Rcpp::DataFrame vert_map_in, Rcpp::IntegerVector fromi, Rcpp::IntegerVector toi_in, const std::string& heap_type, const bool return_weighted);
+RcppExport SEXP _dodgr_rcpp_get_sp_dists_nearest(SEXP graphSEXP, SEXP vert_map_inSEXP, SEXP fromiSEXP, SEXP toi_inSEXP, SEXP heap_typeSEXP, SEXP return_weightedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -264,13 +265,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type fromi(fromiSEXP);
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type toi_in(toi_inSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type heap_type(heap_typeSEXP);
-    rcpp_result_gen = Rcpp::wrap(rcpp_get_sp_dists_nearest(graph, vert_map_in, fromi, toi_in, heap_type));
+    Rcpp::traits::input_parameter< const bool >::type return_weighted(return_weightedSEXP);
+    rcpp_result_gen = Rcpp::wrap(rcpp_get_sp_dists_nearest(graph, vert_map_in, fromi, toi_in, heap_type, return_weighted));
     return rcpp_result_gen;
 END_RCPP
 }
 // rcpp_get_sp_dists_paired_par
-Rcpp::NumericMatrix rcpp_get_sp_dists_paired_par(const Rcpp::DataFrame graph, const Rcpp::DataFrame vert_map_in, Rcpp::IntegerVector fromi, Rcpp::IntegerVector toi, const std::string& heap_type, const bool is_spatial);
-RcppExport SEXP _dodgr_rcpp_get_sp_dists_paired_par(SEXP graphSEXP, SEXP vert_map_inSEXP, SEXP fromiSEXP, SEXP toiSEXP, SEXP heap_typeSEXP, SEXP is_spatialSEXP) {
+Rcpp::NumericMatrix rcpp_get_sp_dists_paired_par(const Rcpp::DataFrame graph, const Rcpp::DataFrame vert_map_in, Rcpp::IntegerVector fromi, Rcpp::IntegerVector toi, const std::string& heap_type, const bool is_spatial, const bool return_weighted);
+RcppExport SEXP _dodgr_rcpp_get_sp_dists_paired_par(SEXP graphSEXP, SEXP vert_map_inSEXP, SEXP fromiSEXP, SEXP toiSEXP, SEXP heap_typeSEXP, SEXP is_spatialSEXP, SEXP return_weightedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -280,7 +282,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type toi(toiSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type heap_type(heap_typeSEXP);
     Rcpp::traits::input_parameter< const bool >::type is_spatial(is_spatialSEXP);
-    rcpp_result_gen = Rcpp::wrap(rcpp_get_sp_dists_paired_par(graph, vert_map_in, fromi, toi, heap_type, is_spatial));
+    Rcpp::traits::input_parameter< const bool >::type return_weighted(return_weightedSEXP);
+    rcpp_result_gen = Rcpp::wrap(rcpp_get_sp_dists_paired_par(graph, vert_map_in, fromi, toi, heap_type, is_spatial, return_weighted));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -300,8 +303,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // rcpp_get_sp_dists
-Rcpp::NumericMatrix rcpp_get_sp_dists(const Rcpp::DataFrame graph, const Rcpp::DataFrame vert_map_in, Rcpp::IntegerVector fromi, Rcpp::IntegerVector toi_in, const std::string& heap_type);
-RcppExport SEXP _dodgr_rcpp_get_sp_dists(SEXP graphSEXP, SEXP vert_map_inSEXP, SEXP fromiSEXP, SEXP toi_inSEXP, SEXP heap_typeSEXP) {
+Rcpp::NumericMatrix rcpp_get_sp_dists(const Rcpp::DataFrame graph, const Rcpp::DataFrame vert_map_in, Rcpp::IntegerVector fromi, Rcpp::IntegerVector toi_in, const std::string& heap_type, const bool return_weighted);
+RcppExport SEXP _dodgr_rcpp_get_sp_dists(SEXP graphSEXP, SEXP vert_map_inSEXP, SEXP fromiSEXP, SEXP toi_inSEXP, SEXP heap_typeSEXP, SEXP return_weightedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -310,7 +313,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type fromi(fromiSEXP);
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type toi_in(toi_inSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type heap_type(heap_typeSEXP);
-    rcpp_result_gen = Rcpp::wrap(rcpp_get_sp_dists(graph, vert_map_in, fromi, toi_in, heap_type));
+    Rcpp::traits::input_parameter< const bool >::type return_weighted(return_weightedSEXP);
+    rcpp_result_gen = Rcpp::wrap(rcpp_get_sp_dists(graph, vert_map_in, fromi, toi_in, heap_type, return_weighted));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -445,11 +449,11 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dodgr_rcpp_unique_rownames", (DL_FUNC) &_dodgr_rcpp_unique_rownames, 3},
     {"_dodgr_rcpp_points_index_par", (DL_FUNC) &_dodgr_rcpp_points_index_par, 2},
     {"_dodgr_rcpp_points_to_edges_par", (DL_FUNC) &_dodgr_rcpp_points_to_edges_par, 2},
-    {"_dodgr_rcpp_get_sp_dists_par", (DL_FUNC) &_dodgr_rcpp_get_sp_dists_par, 6},
-    {"_dodgr_rcpp_get_sp_dists_nearest", (DL_FUNC) &_dodgr_rcpp_get_sp_dists_nearest, 5},
-    {"_dodgr_rcpp_get_sp_dists_paired_par", (DL_FUNC) &_dodgr_rcpp_get_sp_dists_paired_par, 6},
+    {"_dodgr_rcpp_get_sp_dists_par", (DL_FUNC) &_dodgr_rcpp_get_sp_dists_par, 7},
+    {"_dodgr_rcpp_get_sp_dists_nearest", (DL_FUNC) &_dodgr_rcpp_get_sp_dists_nearest, 6},
+    {"_dodgr_rcpp_get_sp_dists_paired_par", (DL_FUNC) &_dodgr_rcpp_get_sp_dists_paired_par, 7},
     {"_dodgr_rcpp_get_iso", (DL_FUNC) &_dodgr_rcpp_get_iso, 5},
-    {"_dodgr_rcpp_get_sp_dists", (DL_FUNC) &_dodgr_rcpp_get_sp_dists, 5},
+    {"_dodgr_rcpp_get_sp_dists", (DL_FUNC) &_dodgr_rcpp_get_sp_dists, 6},
     {"_dodgr_rcpp_get_paths", (DL_FUNC) &_dodgr_rcpp_get_paths, 5},
     {"_dodgr_rcpp_get_paths_pairwise", (DL_FUNC) &_dodgr_rcpp_get_paths_pairwise, 5},
     {"_dodgr_rcpp_get_sp_dists_categorical", (DL_FUNC) &_dodgr_rcpp_get_sp_dists_categorical, 6},

--- a/src/run_sp.cpp
+++ b/src/run_sp.cpp
@@ -1,4 +1,3 @@
-
 #include "run_sp.h"
 
 #include "dgraph.h"
@@ -68,6 +67,7 @@ struct OneDist : public RcppParallel::Worker
     const std::shared_ptr <DGraph> g;
     const std::string heap_type;
     bool is_spatial;
+    bool return_weighted;
 
     RcppParallel::RMatrix <double> dout;
 
@@ -81,10 +81,12 @@ struct OneDist : public RcppParallel::Worker
             const std::shared_ptr <DGraph> g_in,
             const std::string & heap_type_in,
             const bool & is_spatial_in,
+            const bool & return_weighted_in,
             RcppParallel::RMatrix <double> dout_in) :
         dp_fromi (fromi), toi (toi_in), nverts (nverts_in),
         vx (vx_in), vy (vy_in),
         g (g_in), heap_type (heap_type_in), is_spatial (is_spatial_in),
+        return_weighted (return_weighted_in),
         dout (dout_in)
     {
     }
@@ -123,7 +125,7 @@ struct OneDist : public RcppParallel::Worker
             {
                 if (w [toi [j]] < INFINITE_DOUBLE)
                 {
-                    dout (i, j) = d [toi [j]];
+                    dout (i, j) = return_weighted ? w [toi [j]] : d [toi [j]];
                 }
             }
         }
@@ -139,6 +141,7 @@ struct OneDistNearest : public RcppParallel::Worker
     const size_t nfrom;
     const std::shared_ptr <DGraph> g;
     const std::string heap_type;
+    bool return_weighted;
 
     RcppParallel::RVector <double> dout;
 
@@ -150,10 +153,11 @@ struct OneDistNearest : public RcppParallel::Worker
             const size_t nfrom_in,
             const std::shared_ptr <DGraph> g_in,
             const std::string & heap_type_in,
+            const bool & return_weighted_in,
             RcppParallel::RVector <double> dout_in) :
         dp_fromi (fromi), toi (toi_in),
         nverts (nverts_in), nfrom (nfrom_in),
-        g (g_in), heap_type (heap_type_in),
+        g (g_in), heap_type (heap_type_in), return_weighted (return_weighted_in),
         dout (dout_in)
     {
     }
@@ -178,7 +182,7 @@ struct OneDistNearest : public RcppParallel::Worker
             {
                 if (w [toi [j]] < INFINITE_DOUBLE)
                 {
-                    dout [i] = d [toi [j]];
+                    dout [i] = return_weighted ? w [toi [j]] : d [toi [j]];
                     dout [i + nfrom] = toi [j];
                 }
             }
@@ -405,7 +409,8 @@ Rcpp::NumericMatrix rcpp_get_sp_dists_par (const Rcpp::DataFrame graph,
         Rcpp::IntegerVector fromi,
         Rcpp::IntegerVector toi_in,
         const std::string& heap_type,
-        const bool is_spatial)
+        const bool is_spatial,
+        const bool return_weighted)
 {
     std::vector <size_t> toi =
         Rcpp::as <std::vector <size_t> > ( toi_in);
@@ -442,7 +447,7 @@ Rcpp::NumericMatrix rcpp_get_sp_dists_par (const Rcpp::DataFrame graph,
 
     // Create parallel worker
     OneDist one_dist (RcppParallel::RVector <int> (fromi), toi,
-            nverts, vx, vy, g, heap_type, is_spatial,
+            nverts, vx, vy, g, heap_type, is_spatial, return_weighted,
             RcppParallel::RMatrix <double> (dout));
 
     size_t chunk_size = run_sp::get_chunk_size (nfrom);
@@ -459,10 +464,11 @@ Rcpp::NumericVector rcpp_get_sp_dists_nearest (const Rcpp::DataFrame graph,
         const Rcpp::DataFrame vert_map_in,
         Rcpp::IntegerVector fromi,
         Rcpp::IntegerVector toi_in,
-        const std::string& heap_type)
+        const std::string& heap_type,
+        const bool return_weighted)
 {
     std::vector <size_t> toi =
-        Rcpp::as <std::vector <size_t> > (toi_in);
+        Rcpp::as <std::vector <size_t> > ( toi_in);
 
     size_t nfrom = static_cast <size_t> (fromi.size ());
 
@@ -486,7 +492,7 @@ Rcpp::NumericVector rcpp_get_sp_dists_nearest (const Rcpp::DataFrame graph,
 
     // Create parallel worker
     OneDistNearest one_dist (RcppParallel::RVector <int> (fromi), toi,
-            nverts, nfrom, g, heap_type,
+            nverts, nfrom, g, heap_type, return_weighted,
             RcppParallel::RVector <double> (dout));
 
     size_t chunk_size = run_sp::get_chunk_size (nfrom);
@@ -504,7 +510,8 @@ Rcpp::NumericMatrix rcpp_get_sp_dists_paired_par (const Rcpp::DataFrame graph,
         Rcpp::IntegerVector fromi,
         Rcpp::IntegerVector toi,
         const std::string& heap_type,
-        const bool is_spatial)
+        const bool is_spatial,
+        const bool return_weighted)
 {
     if (fromi.size () != toi.size ())
         Rcpp::stop ("pairwise dists must have from.size == to.size");
@@ -610,7 +617,8 @@ Rcpp::NumericMatrix rcpp_get_sp_dists (const Rcpp::DataFrame graph,
         const Rcpp::DataFrame vert_map_in,
         Rcpp::IntegerVector fromi,
         Rcpp::IntegerVector toi_in,
-        const std::string& heap_type)
+        const std::string& heap_type,
+        const bool return_weighted)
 {
     std::vector <size_t> toi =
         Rcpp::as <std::vector <size_t> > ( toi_in);
@@ -663,7 +671,7 @@ Rcpp::NumericMatrix rcpp_get_sp_dists (const Rcpp::DataFrame graph,
         {
             if (w [static_cast <size_t> (toi [j])] < INFINITE_DOUBLE)
             {
-                dout (i, j) = d [static_cast <size_t> (toi [j])];
+                dout (i, j) = return_weighted ? w [static_cast <size_t> (toi [j])] : d [static_cast <size_t> (toi [j])];
             }
         }
     }
@@ -735,7 +743,6 @@ Rcpp::List rcpp_get_paths (const Rcpp::DataFrame graph,
         Rcpp::checkUserInterrupt ();
         std::fill (w.begin(), w.end(), INFINITE_DOUBLE);
         std::fill (d.begin(), d.end(), INFINITE_DOUBLE);
-        std::fill (prev.begin(), prev.end(), INFINITE_INT);
         d [static_cast <size_t> (fromi [i_R])] =
             w [static_cast <size_t> (fromi [i_R])] = 0.0;
 
@@ -817,7 +824,6 @@ Rcpp::List rcpp_get_paths_pairwise (const Rcpp::DataFrame graph,
         Rcpp::checkUserInterrupt ();
         std::fill (w.begin(), w.end(), INFINITE_DOUBLE);
         std::fill (d.begin(), d.end(), INFINITE_DOUBLE);
-        std::fill (prev.begin(), prev.end(), INFINITE_INT);
         d [static_cast <size_t> (fromi [i_R])] =
             w [static_cast <size_t> (fromi [i_R])] = 0.0;
 

--- a/src/run_sp.h
+++ b/src/run_sp.h
@@ -59,27 +59,31 @@ Rcpp::NumericMatrix rcpp_get_sp_dists (const Rcpp::DataFrame graph,
         const Rcpp::DataFrame vert_map_in,
         Rcpp::IntegerVector fromi,
         Rcpp::IntegerVector toi_in,
-        const std::string& heap_type);
+        const std::string& heap_type,
+        const bool return_weighted);
 
 Rcpp::NumericMatrix rcpp_get_sp_dists_par (const Rcpp::DataFrame graph,
         const Rcpp::DataFrame vert_map_in,
         Rcpp::IntegerVector fromi,
         Rcpp::IntegerVector toi_in,
         const std::string& heap_type,
-        const bool is_spatial);
+        const bool is_spatial,
+        const bool return_weighted);
 
 Rcpp::NumericVector rcpp_get_sp_dists_nearest (const Rcpp::DataFrame graph,
         const Rcpp::DataFrame vert_map_in,
         Rcpp::IntegerVector fromi,
         Rcpp::IntegerVector toi_in,
-        const std::string& heap_type);
+        const std::string& heap_type,
+        const bool return_weighted);
 
 Rcpp::NumericMatrix rcpp_get_sp_dists_paired_par (const Rcpp::DataFrame graph,
         const Rcpp::DataFrame vert_map_in,
         Rcpp::IntegerVector fromi,
         Rcpp::IntegerVector toi,
         const std::string& heap_type,
-        const bool is_spatial);
+        const bool is_spatial,
+        const bool return_weighted);
 
 Rcpp::NumericMatrix rcpp_get_iso (const Rcpp::DataFrame graph,
         const Rcpp::DataFrame vert_map_in,


### PR DESCRIPTION
Implements #275 

This PR adds the ability to return weighted distances in `dodgr_dists`.

Currently dodgr_dists always returns geometric distances. This enhancement adds the ability to return weighted distances instead, which is useful for routing scenarios where we need to select departure points based on weighted (and not actual) distance.

Proposed functionality:

Add return_weighted parameter to dodgr_dists
When return_weighted = TRUE, return weighted distances from the graph
When return_weighted = FALSE (default), maintain current behavior of returning geometric distances

